### PR TITLE
refactor: allow unauthenticated users to access the blog posts

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -23,7 +23,7 @@ class PostController extends BaseController
 
     public function __construct()
     {
-        $this->middleware('auth')->except(['list', 'detail']);
+        $this->middleware('auth')->except(['index', 'show']);
     }
 
     public function index(): Response

--- a/tests/Feature/PostTest.php
+++ b/tests/Feature/PostTest.php
@@ -200,4 +200,33 @@ test('post deletion requires authentication', function () {
     $response = $this->delete(route('posts.destroy', $post));
 
     $response->assertRedirect(route('login'));
+});
+
+test('unauthenticated user can view posts index page', function () {
+    $user = User::factory()->create();
+    $posts = Post::factory()->count(3)->create(['user_id' => $user->id]);
+
+    $response = $this->get(route('posts.index'));
+
+    $response->assertInertia(fn ($assert) => $assert
+        ->component('posts/list')
+        ->has('posts', 3)
+        ->where('posts.0.title', $posts[0]->title)
+        ->where('posts.1.title', $posts[1]->title)
+        ->where('posts.2.title', $posts[2]->title)
+    );
+});
+
+test('unauthenticated user can view post detail page', function () {
+    $user = User::factory()->create();
+    $post = Post::factory()->create(['user_id' => $user->id]);
+
+    $response = $this->get(route('posts.show', $post));
+
+    $response->assertInertia(fn ($assert) => $assert
+        ->component('posts/show')
+        ->where('post.title', $post->title)
+        ->where('post.content', $post->content)
+        ->where('canEdit', false)
+    );
 }); 


### PR DESCRIPTION
Resolves #4 

# What Changed

- Fixed incorrect middleware exception in PostController to ensures that unauthenticated users can properly access the blog 
- Added feature tests to verify public access to blog content

# Testing Instructions
1. Test unauthenticated user can view posts index page
2. Test unauthenticated user can view post detail page

# Screenshots
![image](https://github.com/user-attachments/assets/3e462056-4d2a-4974-bedd-f50d0a9dde81)
![image](https://github.com/user-attachments/assets/009337fe-4685-455e-bf38-2e07f54049ee)
