### PR TITLE
chore: generate 20+ fake posts for testing

### DIFF
--- a/database/factories/PostFactory.php
+++ b/database/factories/PostFactory.php
@@ -5,6 +5,8 @@ namespace Database\Factories;
 use App\Models\Post;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 
 /**
@@ -53,8 +55,16 @@ class PostFactory extends Factory
      */
     public function withFeaturedImage(): static
     {
-        return $this->state(fn (array $attributes) => [
-            'featured_image' => 'posts/' . fake()->uuid() . '.jpg',
-        ]);
+        return $this->state(function (array $attributes) {
+            // Create a fake image
+            $image = UploadedFile::fake()->image('post.jpg', 800, 600);
+            
+            // Store the image in the public disk
+            $path = $image->store('posts', 'public');
+            
+            return [
+                'featured_image' => $path,
+            ];
+        });
     }
 } 

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -13,11 +13,15 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // User::factory(10)->create();
-
+        // Create a test user for development
         User::factory()->create([
             'name' => 'Test User',
             'username' => 'testuser',
+        ]);
+
+        // Run the post seeder
+        $this->call([
+            PostSeeder::class,
         ]);
     }
 }

--- a/database/seeders/PostSeeder.php
+++ b/database/seeders/PostSeeder.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Post;
+use App\Models\User;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Storage;
+
+class PostSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        // Clear any existing images in the posts directory
+        Storage::disk('public')->deleteDirectory('posts');
+        
+        // Create a few users to have posts from different authors
+        $users = User::factory()->count(3)->create();
+
+        // Create 15 posts with varied content
+        Post::factory()
+            ->count(15)
+            ->sequence(
+                // Mix of posts with and without featured images
+                ['featured_image' => null],
+                fn () => Post::factory()->withFeaturedImage()->make()->getAttributes(),
+            )
+            ->sequence(function () use ($users) {
+                // Randomly assign posts to different users
+                return ['user_id' => $users->random()->id];
+            })
+            ->create();
+
+        // Create some additional posts with specific states
+        Post::factory()
+            ->count(5)
+            ->withFeaturedImage()
+            ->create([
+                'user_id' => $users->first()->id,
+                'content' => fake()->paragraphs(5, true), // Longer content
+            ]);
+    }
+} 


### PR DESCRIPTION
Resolves #5 

# What Changed

- Added a robust seeding setup:
  - Creates a test user (`testuser`) and 3 random users
  - Seeds 20 posts with varied content and random authors
- Updated `PostFactory` to generate real fake images using `UploadedFile::fake()->image()`

# Testing Instructions

- Run `php artisan migrate:fresh --seed`
- Then visit /posts and confirm that fake posts are displayed

# Screenshots
![image](https://github.com/user-attachments/assets/40694443-8e3a-412a-9cc9-ae03794158e5)
